### PR TITLE
Fix links table creation

### DIFF
--- a/database/migrations/2019_09_15_180846_create_links_table.php
+++ b/database/migrations/2019_09_15_180846_create_links_table.php
@@ -15,7 +15,7 @@ class CreateLinksTable extends Migration
     {
         Schema::create('links', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->integer('organization_id');
+            $table->unsignedBigInteger('organization_id');
             $table->string('url')->unique();
             $table->integer('click_count')->default(0);
             $table->string('type')->default('website');


### PR DESCRIPTION
Fix the order in which the tables organizations and links are created and change the type of organization_id to unsignedBigInteger.