### PR TITLE
Sticky share buttons

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -11,7 +11,7 @@
 
     <!-- Scripts -->
     <script src="{{ asset('js/app.js') }}" defer></script>
-    <script type='text/javascript' src='https://platform-api.sharethis.com/js/sharethis.js#property=5d9266c22f2b07001290d96f&product=sticky-share-buttons' async='async'></script>
+    <script type='text/javascript' src='//platform-api.sharethis.com/js/sharethis.js#property=5bee9ee57c3c810011b38b75&product=inline-share-buttons' async='async'></script>
     @livewireAssets
 
     <!-- Fonts -->
@@ -24,10 +24,9 @@
   </head>
   <body>
       @include('inc.navbar')
-
-      <div class=”sharethis-inline-share-buttons”></div>
       
       <main class="py-4">
+        <div class=”sharethis-inline-share-buttons”></div>
         <div class="container mb-30">
           <div class="row">
             @yield('content')


### PR DESCRIPTION
The old website uses [ShareThis](https://platform.sharethis.com/) to add sticky share buttons. There is a Property id to use the API with a specific configuration like which social media links to include ...

I kept the same property id on the new website, to get the same bar.