### PR TITLE
Fix external link clicks being lost

### DIFF
--- a/app/Http/Controllers/OrganizationClicksController.php
+++ b/app/Http/Controllers/OrganizationClicksController.php
@@ -9,7 +9,7 @@ class OrganizationClicksController extends Controller
 {
     public function store(Organization $organization)
     {
-        if ($organization->website) {
+        if ($organization->website()) {
             event(new OrgLinkClicked($organization, auth()->user() ?: null));
         }
     }

--- a/resources/views/components/links/website.blade.php
+++ b/resources/views/components/links/website.blade.php
@@ -1,7 +1,7 @@
 <a href="{{ $url }}?ref=veganactivism.org"
    target="_blank"
    class="btn btn-danger ml-3 my-1 py-1"
-   onclick="axios.post('{{route('organizations.clicks.store', $organization['id'])}}')"
+   onclick="axios.post('{{route('organizations.clicks.store', $organization['slug'])}}')"
 >
   <i class="fas fa-link mr-2"></i>Visit Website
 </a>

--- a/resources/views/livewire/org-home-card.blade.php
+++ b/resources/views/livewire/org-home-card.blade.php
@@ -17,7 +17,7 @@
       <div class="my-2 mx-1 row">
         <a href="{{ $organization['show_route'] }}" class="btn btn-dark py-1"><i class="fas fa-info-circle mr-1"></i>Learn More</a>
         <a href="{{ $organization['website_url'] }}" target="_blank" class="btn btn-danger ml-3 py-1"
-           onclick="axios.post('{{route('organizations.clicks.store', $organization['id'])}}')">
+           onclick="axios.post('{{route('organizations.clicks.store', $organization['slug'])}}')">
           <i class="fas fa-link mr-1"></i>Visit Website
         </a>
       </div>


### PR DESCRIPTION
The clicks on links to the external websites were not being counted.
This was caused by two issues:

1st is that we were passing the org id to the route, but the
Organization model defines the slug as the routeKeyName. This meant it
would always 404 as it would look for a slug that matched the DB id!

2nd issue was to do with how the website property on thge Organization
was being access in the OrganizationClicksController. It was referenced
as a property instead of a function, which was throwing
`App\Organization::website must return a relationship
instance.` Changing it to ->website() to match how it's used in
OrganizationController@show fixes this.

See: https://trello.com/c/49OMDZ88/75-confirm-that-our-unique-clicks-counter-is-still-working-for-the-visit-website-buttons-on-homepage-and-on-the-org-pages